### PR TITLE
Añadidas las coordenadas de Ángel Vaca

### DIFF
--- a/points.geojson
+++ b/points.geojson
@@ -106,6 +106,17 @@
       ]
     }
   },
-  
-  
+  {
+    "type": "Feature",
+    "name": "points_AngelVaca",
+    "properties": {},
+    "geometry": {
+      "type": "Point",
+      "coordinates": [
+        38.8704091, 
+        -6.9788558
+      ]
+    }
+  }
+  ] 
 }


### PR DESCRIPTION
Añadidas las coordenadas de Ángel Vaca
Además, se ha corregido un error en el fichero (quizás debería haber subido esto en dos versiones, en lugar de sólo en una...)