### PR TITLE
Añadidas las coordenadas de Tabaré Martínez

### DIFF
--- a/points.geojson
+++ b/points.geojson
@@ -418,6 +418,19 @@
                     43.315207
                 ]
             }
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "name": "Tabaré Martínez"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -64.29000636681559, 
+                    -31.33454457341891
+                ]
+            }
         }
     ]
 }


### PR DESCRIPTION
Solicito la autorización para agregar las coordenadas de Tabaré Martínez en el repositorio original.
Lo que se modificó fue le archivo points.geojson.